### PR TITLE
ci: revert to classic golangci-lint action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,17 +1,20 @@
-name: Code analysis
+name: Code Analysis
 
-on: [pull_request]
+on: [ push, pull_request ]
 
 jobs:
-  golangci-lint:
+  lint:
+    if: "!contains(github.event.head_commit.message, 'autoupdate')"
     runs-on: ubuntu-latest
     steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
         with:
-          fetch-depth: 0
-      - name: Linting with golangci-lint
-        uses: reviewdog/action-golangci-lint@v2
+          go-version: 'stable'
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
         with:
-          github_token: ${{ secrets.ACCESS_TOKEN }}
-          reporter: github-pr-review
+          version: latest


### PR DESCRIPTION
To ensure CI linter works for PR revert to classic golangci-lint action following the approach from https://github.com/pterm/pterm/commit/e922ca0dba9001136a4dd4128efb45be521d6568) 

This should fix errors for workflows