### PR TITLE
make area use default cursor writer

### DIFF
--- a/area.go
+++ b/area.go
@@ -18,7 +18,7 @@ type Area struct {
 func NewArea() Area {
 	return Area{
 		height:     0,
-		writer:     os.Stdout,
+		writer:     cursor.writer,
 		cursor:     cursor,
 		cursorPosY: 0,
 	}


### PR DESCRIPTION
Make the area use the default cursor writer so that if the default cursor is set, then its write is used within the area writer.

I'm pretty sure this is the correct behaviour that should be happening, but let me also describe the problem i'm facing.

I'm writing tests that interact with the CLI elements, and i have been struggling to redirect the output of the interactive widgets away from stdout, I'm using this library via pterm, and i found a function in pterm `pterm.SetDefaultOutput` which could redirect output, i found that cursor had `cursor.SetTarget` but default areas were hard coded to stdout.  I could add a way to explicitly set the default area writer, but i'm not familiar with the usecases of setting a default writer to know if you would ever want the cursor to have a different writer to the area.