### PR TITLE
ANSI escape codes should only be written if writer is a TTY

### DIFF
--- a/cursor_other.go
+++ b/cursor_other.go
@@ -5,32 +5,39 @@ package cursor
 
 import (
 	"fmt"
+	"golang.org/x/term"
 )
+
+func (c *Cursor) isTerminal() bool {
+	return term.IsTerminal(int(c.writer.Fd()))
+}
 
 // Up moves the cursor n lines up relative to the current position.
 func (c *Cursor) Up(n int) {
-	if n > 0 {
-		fmt.Fprintf(c.writer, "\x1b[%dA", n)
+	if c.isTerminal() {
+		if n > 0 {
+			fmt.Fprintf(c.writer, "\x1b[%dA", n)
+		}
 	}
 }
 
 // Down moves the cursor n lines down relative to the current position.
 func (c *Cursor) Down(n int) {
-	if n > 0 {
+	if c.isTerminal() && n > 0 {
 		fmt.Fprintf(c.writer, "\x1b[%dB", n)
 	}
 }
 
 // Right moves the cursor n characters to the right relative to the current position.
 func (c *Cursor) Right(n int) {
-	if n > 0 {
+	if c.isTerminal() && n > 0 {
 		fmt.Fprintf(c.writer, "\x1b[%dC", n)
 	}
 }
 
 // Left moves the cursor n characters to the left relative to the current position.
 func (c *Cursor) Left(n int) {
-	if n > 0 {
+	if c.isTerminal() && n > 0 {
 		fmt.Fprintf(c.writer, "\x1b[%dD", n)
 	}
 }
@@ -38,30 +45,40 @@ func (c *Cursor) Left(n int) {
 // HorizontalAbsolute moves the cursor to n horizontally.
 // The position n is absolute to the start of the line.
 func (c *Cursor) HorizontalAbsolute(n int) {
-	n++ // Moves the line to the character after n
-	fmt.Fprintf(c.writer, "\x1b[%dG", n)
+	if c.isTerminal() {
+		n++ // Moves the line to the character after n
+		fmt.Fprintf(c.writer, "\x1b[%dG", n)
+	}
 }
 
 // Show the cursor if it was hidden previously.
 // Don't forget to show the cursor at least at the end of your application.
 // Otherwise the user might have a terminal with a permanently hidden cursor, until they reopen the terminal.
 func (c *Cursor) Show() {
-	fmt.Fprint(c.writer, "\x1b[?25h")
+	if c.isTerminal() {
+		fmt.Fprint(c.writer, "\x1b[?25h")
+	}
 }
 
 // Hide the cursor.
 // Don't forget to show the cursor at least at the end of your application with Show.
 // Otherwise the user might have a terminal with a permanently hidden cursor, until they reopen the terminal.
 func (c *Cursor) Hide() {
-	fmt.Fprintf(c.writer, "\x1b[?25l")
+	if c.isTerminal() {
+		fmt.Fprintf(c.writer, "\x1b[?25l")
+	}
 }
 
 // ClearLine clears the current line and moves the cursor to it's start position.
 func (c *Cursor) ClearLine() {
-	fmt.Fprintf(c.writer, "\x1b[2K")
+	if c.isTerminal() {
+		fmt.Fprintf(c.writer, "\x1b[2K")
+	}
 }
 
 // Clear clears the current position and moves the cursor to the left.
 func (c *Cursor) Clear() {
-	fmt.Fprintf(c.writer, "\x1b[K")
+	if c.isTerminal() {
+		fmt.Fprintf(c.writer, "\x1b[K")
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module atomicgo.dev/cursor
 
 go 1.15
+
+require golang.org/x/term v0.14.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+golang.org/x/sys v0.14.0 h1:Vz7Qs629MkJkGyHxUlRHizWJRG2j8fbQKjELVSNhy7Q=
+golang.org/x/sys v0.14.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/term v0.14.0 h1:LGK9IlZ8T9jvdy6cTdfKUCltatMFOehAQo9SRC46UQ8=
+golang.org/x/term v0.14.0/go.mod h1:TySc+nGkYR6qt8km8wUhuFRTVSMIX3XPR58y2lC8vww=


### PR DESCRIPTION
ANSI escape codes should only be written when the `writer` is a terminal.

This is important when the output is redirect to a file for example.

This would solve https://github.com/atomicgo/cursor/issues/24
